### PR TITLE
remove client logger in favor of config logger

### DIFF
--- a/pkg/permit/permit.go
+++ b/pkg/permit/permit.go
@@ -6,12 +6,10 @@ import (
 	config "github.com/permitio/permit-golang/pkg/config"
 	"github.com/permitio/permit-golang/pkg/enforcement"
 	"github.com/permitio/permit-golang/pkg/models"
-	"go.uber.org/zap"
 )
 
 type Client struct {
 	config      config.PermitConfig
-	logger      *zap.Logger
 	Api         *api.PermitApiClient
 	Elements    *api.Elements
 	enforcement *enforcement.PermitEnforcer
@@ -20,21 +18,17 @@ type Client struct {
 var New = NewPermit
 
 func NewPermit(config config.PermitConfig) *Client {
-	logger, err := zap.NewProduction()
-	if err != nil {
-		panic(err)
-	}
 	ctx := context.Background()
 	apiClient := api.NewPermitApiClient(ctx, &config)
 	enforcerClient := enforcement.NewPermitEnforcerClient(&config)
 	return &Client{
 		config:      config,
-		logger:      logger,
 		Api:         apiClient,
 		Elements:    apiClient.Elements,
 		enforcement: enforcerClient,
 	}
 }
+
 func (c *Client) SyncUser(ctx context.Context, user models.UserCreate) (*models.UserRead, error) {
 	return c.Api.Users.SyncUser(ctx, user)
 }


### PR DESCRIPTION
Logger created by `permit.New` is redundant as other components use the logger passed (or created) by `PermitConfig`.

This PR removes the logger in favor of the config logger.