### PR TITLE
Updating interface to match implementation

### DIFF
--- a/pkg/permit/permit.go
+++ b/pkg/permit/permit.go
@@ -55,7 +55,7 @@ type PermitInterface interface {
 	Check(user enforcement.User, action enforcement.Action, resource enforcement.Resource) (bool, error)
 	BulkCheck(requests ...enforcement.CheckRequest) ([]bool, error)
 	FilterObjects(user enforcement.User, action enforcement.Action, context map[string]string, resources ...enforcement.ResourceI) ([]enforcement.ResourceI, error)
-	AllTenantsCheck(request enforcement.CheckRequest) ([]enforcement.TenantDetails, error)
+	AllTenantsCheck(user enforcement.User, action enforcement.Action, resource enforcement.Resource) ([]enforcement.TenantDetails, error)
 	GetUserPermissions(user enforcement.User, tenants ...string) (enforcement.UserPermissions, error)
 	SyncUser(ctx context.Context, user models.UserCreate) (*models.UserRead, error)
 }


### PR DESCRIPTION
Simple change to update interface to match implementation. Apparently the code doesn't have any other implementations of the interface, and no usages, even in tests, so this should be a low-impact change.

Addresses #50