### PR TITLE
Config: Updating interface to match implementation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type IPermitConfig interface {
 	GetContext() *PermitContext
 	GetLogger() *zap.Logger
 	GetProxyFactsViaPDP() bool
-	GetFactsSyncTimeout() *int64
+	GetFactsSyncTimeout() *time.Duration
 	GetHTTPClient() *http.Client
 }
 


### PR DESCRIPTION
PermitConfig also didn't match between interface and implementation.