### PR TITLE
fix: correct WaitForSync method implementations to use WaitForSyncOpt…

### DIFF
--- a/pkg/api/relationshipTuples.go
+++ b/pkg/api/relationshipTuples.go
@@ -33,7 +33,11 @@ func NewRelationshipTuplesApi(client *openapi.APIClient, config *config.PermitCo
 //   - timeout: Optional duration to wait for synchronization.
 //   - policy: Optional policy to apply when timeout is reached ("ignore" or "fail").
 func (u *RelationshipTuples) WaitForSync(timeout *time.Duration, policy ...config.FactsSyncTimeoutPolicy) *RelationshipTuples {
-	return NewRelationshipTuplesApi(u.PermitBaseFactsApi.WaitForSync(timeout, policy...).client, u.config)
+	options := WaitForSyncOptions{}
+	if len(policy) > 0 {
+		options.Policy = policy[0]
+	}
+	return NewRelationshipTuplesApi(u.PermitBaseFactsApi.WaitForSync(timeout, options).client, u.config)
 }
 
 func (r *RelationshipTuples) Create(

--- a/pkg/api/resourceInstances.go
+++ b/pkg/api/resourceInstances.go
@@ -34,7 +34,11 @@ func NewResourceInstancesApi(client *openapi.APIClient, config *config.PermitCon
 //   - timeout: Optional duration to wait for synchronization.
 //   - policy: Optional policy to apply when timeout is reached ("ignore" or "fail").
 func (r *ResourceInstances) WaitForSync(timeout *time.Duration, policy ...config.FactsSyncTimeoutPolicy) *ResourceInstances {
-	return NewResourceInstancesApi(r.PermitBaseFactsApi.WaitForSync(timeout, policy...).client, r.config)
+	options := WaitForSyncOptions{}
+	if len(policy) > 0 {
+		options.Policy = policy[0]
+	}
+	return NewResourceInstancesApi(r.PermitBaseFactsApi.WaitForSync(timeout, options).client, r.config)
 }
 
 func (r *ResourceInstances) Create(

--- a/pkg/api/roleAssignments.go
+++ b/pkg/api/roleAssignments.go
@@ -33,7 +33,11 @@ func NewRoleAssignmentsApi(client *openapi.APIClient, config *config.PermitConfi
 //   - timeout: Optional duration to wait for synchronization.
 //   - policy: Optional policy to apply when timeout is reached ("ignore" or "fail").
 func (r *RoleAssignments) WaitForSync(timeout *time.Duration, policy ...config.FactsSyncTimeoutPolicy) *RoleAssignments {
-	return NewRoleAssignmentsApi(r.PermitBaseFactsApi.WaitForSync(timeout, policy...).client, r.config)
+	options := WaitForSyncOptions{}
+	if len(policy) > 0 {
+		options.Policy = policy[0]
+	}
+	return NewRoleAssignmentsApi(r.PermitBaseFactsApi.WaitForSync(timeout, options).client, r.config)
 }
 
 func (r *RoleAssignments) List(ctx context.Context, page int, perPage int, userFilter, roleFilter, tenantFilter string) (*[]models.RoleAssignmentRead, error) {

--- a/pkg/api/tenants.go
+++ b/pkg/api/tenants.go
@@ -34,7 +34,11 @@ func NewTenantsApi(client *openapi.APIClient, config *config.PermitConfig) *Tena
 //   - timeout: Optional duration to wait for synchronization.
 //   - policy: Optional policy to apply when timeout is reached ("ignore" or "fail").
 func (t *Tenants) WaitForSync(timeout *time.Duration, policy ...config.FactsSyncTimeoutPolicy) *Tenants {
-	return NewTenantsApi(t.PermitBaseFactsApi.WaitForSync(timeout, policy...).client, t.config)
+	options := WaitForSyncOptions{}
+	if len(policy) > 0 {
+		options.Policy = policy[0]
+	}
+	return NewTenantsApi(t.PermitBaseFactsApi.WaitForSync(timeout, options).client, t.config)
 }
 
 // List all tenants under the context's environment.

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -35,7 +35,11 @@ func NewUsersApi(client *openapi.APIClient, config *config.PermitConfig) *Users 
 //   - timeout: Optional duration to wait for synchronization.
 //   - policy: Optional policy to apply when timeout is reached ("ignore" or "fail").
 func (u *Users) WaitForSync(timeout *time.Duration, policy ...config.FactsSyncTimeoutPolicy) *Users {
-	return NewUsersApi(u.PermitBaseFactsApi.WaitForSync(timeout, policy...).client, u.config)
+	options := WaitForSyncOptions{}
+	if len(policy) > 0 {
+		options.Policy = policy[0]
+	}
+	return NewUsersApi(u.PermitBaseFactsApi.WaitForSync(timeout, options).client, u.config)
 }
 
 // List the users from your context's environment.


### PR DESCRIPTION
The WaitForSync methods in various API clients were incorrectly passing variadic 
policy arguments directly to the base PermitBaseFactsApi.WaitForSync method. 
This fix properly converts the variadic arguments into the expected 
WaitForSyncOptions struct format.

Affected files:
- pkg/api/relationshipTuples.go
- pkg/api/resourceInstances.go
- pkg/api/roleAssignments.go
- pkg/api/tenants.go
- pkg/api/users.go