### PR TITLE
add input filters to getuserpermissions (take2)

### DIFF
--- a/pkg/permit/permit.go
+++ b/pkg/permit/permit.go
@@ -2,6 +2,7 @@ package permit
 
 import (
 	"context"
+
 	"github.com/permitio/permit-golang/pkg/api"
 	config "github.com/permitio/permit-golang/pkg/config"
 	"github.com/permitio/permit-golang/pkg/enforcement"
@@ -51,11 +52,16 @@ func (c *Client) GetUserPermissions(user enforcement.User, tenants ...string) (e
 	return c.enforcement.GetUserPermissions(user, tenants...)
 }
 
+func (c *Client) GetUserPermissionsWithOptions(user enforcement.User, opts ...enforcement.UserPermissionsOption) (enforcement.UserPermissions, error) {
+	return c.enforcement.GetUserPermissionsWithOptions(user, opts...)
+}
+
 type PermitInterface interface {
 	Check(user enforcement.User, action enforcement.Action, resource enforcement.Resource) (bool, error)
 	BulkCheck(requests ...enforcement.CheckRequest) ([]bool, error)
 	FilterObjects(user enforcement.User, action enforcement.Action, context map[string]string, resources ...enforcement.ResourceI) ([]enforcement.ResourceI, error)
 	AllTenantsCheck(user enforcement.User, action enforcement.Action, resource enforcement.Resource) ([]enforcement.TenantDetails, error)
 	GetUserPermissions(user enforcement.User, tenants ...string) (enforcement.UserPermissions, error)
+	GetUserPermissionsWithOptions(user enforcement.User, opts ...enforcement.UserPermissionsOption) (enforcement.UserPermissions, error)
 	SyncUser(ctx context.Context, user models.UserCreate) (*models.UserRead, error)
 }


### PR DESCRIPTION
# Enhanced GetUserPermissions API with Full Filtering Support

This PR enhances the GetUserPermissions API to support the full range of filtering options available in the Permit.io PDP API:

## 1. Added Support for Additional Filter Parameters
- Resource types (`resource_types`)
- Specific resources (`resources`) 
- Context data (including ABAC support via `enable_abac_user_permissions`)

## 2. Implemented Using the Functional Options Pattern
- Created option functions: `WithTenants`, `WithResourceTypes`, `WithResources`, `WithContext`
- Allows for flexible, readable API usage with any combination of filters

## 3. Maintained Backward Compatibility
- Signature of existing GetUserPermissions didn't change
- Added `GetUserPermissionsWithOptions` to support advanced filtering


These changes enable filtering user permissions by tenant, resource type, and specific resources while adding support for ABAC-related context data, all while maintaining backward compatibility with existing code.
